### PR TITLE
Set required shard count for Q8 quest

### DIFF
--- a/src/main/java/com/maks/mydungeonteleportplugin/quests/QuestManager.java
+++ b/src/main/java/com/maks/mydungeonteleportplugin/quests/QuestManager.java
@@ -152,6 +152,15 @@ public class QuestManager {
             // Skip to collection phase - need to set objective explicitly
             questState.setCurrentObjective(QuestState.QuestObjective.COLLECT_FROM_MOBS);
 
+            // Set the required number of shards for collection objective
+            if (questData != null && questData.hasCollectObjectives(1)) {
+                Map<String, QuestData.CollectObjective> objectives = questData.getCollectObjectives(1);
+                if (!objectives.isEmpty()) {
+                    QuestData.CollectObjective objective = objectives.values().iterator().next();
+                    questState.setRequiredItems(objective.getCount());
+                }
+            }
+
         } else if (questId.startsWith("q9_")) {
             questState.setLocationFound(true);
 


### PR DESCRIPTION
## Summary
- Initialize required item count for Q8 quests so electrical shard drops work correctly

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688dce0320d8832abecef0a9e196c4d0